### PR TITLE
Remove hard pin of ruaml.yaml

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:
@@ -21,7 +21,7 @@ requirements:
   run:
     - python >=2.7
     - python-dateutil >=2.6.0
-    - ruamel.yaml 0.17.4
+    - ruamel.yaml >=0.17
 
 test:
   imports:


### PR DESCRIPTION
I was about to open an issue but thought I might as well open a PR directly to encourage the discussion.

Usually libraries such as this don't pin exact versions. This PR uses a lower bound which seems reasonable.

This was originally added in 34ed7082b1b4e735ec0c10b6a1bcc746a26c94c8, but this seems too restrictive, and I couldn't find a discussion on why the pin is there ([as it is not in the upstream repository either](https://github.com/crdoconnor/strictyaml/blob/1.6.1/setup.py)).

